### PR TITLE
Fix compilation on Mac.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,17 @@
 from setuptools import setup, find_packages
+from distutils.extension import Extension
 from Cython.Build import cythonize
 import numpy as np
 
+
+ext_modules=[
+    Extension(
+        "stm.rmsd.qcp",
+        sources=["stm/rmsd/qcp.pyx"],
+        include_dirs=[np.get_include()]
+        )
+    ]
+    
 setup(
     name='structural-template-matching',
     version='1.0',
@@ -10,6 +20,5 @@ setup(
     author_email='jamad@fysik.dtu.dk',
     packages=find_packages(),  #same as name
     install_requires=[], #external packages as dependencies
-    ext_modules=cythonize("stm/rmsd/qcp.pyx"),
-    include_dirs=[np.get_include()]
+    ext_modules=cythonize(ext_modules),
 )


### PR DESCRIPTION
This works around a bug in setuptools, where the include_dirs argument to
setup() is ignored if some configuration file was installed together with
Python.  On a Mac, this configuration file is present.