### PR TITLE
Peak datatypes

### DIFF
--- a/stm/feature/peaks.py
+++ b/stm/feature/peaks.py
@@ -69,9 +69,10 @@ def find_local_peaks(image, min_distance, threshold=0, local_threshold=0,
     if exclude_adjacent:
         labels = label(is_peak)
         peaks = center_of_mass(np.ones_like(labels[0]), labels[0], range(1,labels[1]+1))
+        peaks = np.array(peaks)
     else:
         peaks = np.array(np.where(is_peak)).T
-        
+
     return peaks
     
 def refine_peaks(image, points, region=3, model='gaussian', progress_bar=False):

--- a/stm/feature/peaks.py
+++ b/stm/feature/peaks.py
@@ -111,6 +111,11 @@ def refine_peaks(image, points, region=3, model='gaussian', progress_bar=False):
     region = np.array(region).astype(bool)
     
     refined = np.zeros_like(points, dtype=float)
+
+    # Point may be floats, if exclude_adjacent was passed
+    # to find_local_peaks.  If so, round and cast.
+    if not issubclass(points.dtype.type, np.integer):
+        points = np.rint(points).astype(int)
     
     X,Y = np.indices(image.shape)
     


### PR DESCRIPTION
if exclude_adjacent=True was passed to find_local_peaks(), the result
was returned as a list instead of a numpy array.  In addition, the peaks
are now floats, which broke refine_peaks().  

This PR makes sure that find_local_peaks() returns a numpy array, and
that refine_peaks() accepts floats.
