### PR TITLE
Fix syntax error.

### DIFF
--- a/stm/register/match.py
+++ b/stm/register/match.py
@@ -127,7 +127,7 @@ class AngularSortRMSD(RMSD):
     
     def __init__(self, segments, templates):
         
-        self.permutations = 
+        self.permutations = None
     
     def get_rmsd(self, i, j):
         


### PR DESCRIPTION
 The class in question is incomplete but now the file loads.

The syntax error prevented installation.
